### PR TITLE
fix: use file: instead of absolute file path

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,13 +21,13 @@ ipm install excalidraw
 Write a link with `!Excalidraw` caption like:
 
 ```markdown
-[!Excalidraw](/path/to/file.excalidraw)
+[!Excalidraw](file:///path/to/file.excalidraw)
 ```
 
 or 
 
 ```markdown
-![Excalidraw](/path/to/file.excalidraw.png)
+![Excalidraw](file:///path/to/file.excalidraw.png)
 ```
 
 Preview the note, and you can edit the file as excalidraw file.

--- a/lib/excalidraw.js
+++ b/lib/excalidraw.js
@@ -57,7 +57,7 @@ module.exports = {
   config: {
     saveDir: {
       title: "A saving directory for .excalidraw files",
-      description: "Put the path to directory for savind .excalidraw files",
+      description: "Put the path to directory for savind .excalidraw files. e.g. /path/to/excalidraw-files/",
       type: "string",
       default: ""
     },
@@ -83,7 +83,7 @@ module.exports = {
         }
 
         const outputFilePath = createExcalidraw(saveDir);
-        insertText(`[!Excalidraw](${outputFilePath})`);
+        insertText(`[!Excalidraw](${outputFilePath.toString()})`);
       }
     }));
   },

--- a/lib/excalidraw.js
+++ b/lib/excalidraw.js
@@ -8,6 +8,8 @@ var _eventKit = require("event-kit");
 
 var _fs = _interopRequireDefault(require("fs"));
 
+var _url = _interopRequireDefault(require("url"));
+
 var _path = _interopRequireDefault(require("path"));
 
 var _dayjs = _interopRequireDefault(require("dayjs"));
@@ -20,6 +22,12 @@ const insertText = text => {
   const cm = inkdrop.getActiveEditor().cm;
   cm.replaceSelection(text + "\n");
 };
+/**
+ * Create new .excalidraw file and return file:/// url
+ * @param dirPath
+ * @returns {URL}
+ */
+
 
 const createExcalidraw = dirPath => {
   const DEFAULT_STATE = {
@@ -40,7 +48,7 @@ const createExcalidraw = dirPath => {
 
   _fs.default.writeFileSync(filePath, JSON.stringify(DEFAULT_STATE), "utf-8");
 
-  return filePath;
+  return _url.default.pathToFileURL(filePath);
 };
 
 const subscriptions = new _eventKit.CompositeDisposable();

--- a/lib/providers/excalidraw.js
+++ b/lib/providers/excalidraw.js
@@ -39,9 +39,7 @@ function test(filePathOrUrl) {
     return false;
   }
 
-  const isLocalPath = _path.default.isAbsolute(filePathOrUrl) || filePathOrUrl.startsWith("file:");
-
-  if (!isLocalPath) {
+  if (!filePathOrUrl.startsWith("file:")) {
     return false;
   }
 

--- a/lib/providers/excalidraw.js
+++ b/lib/providers/excalidraw.js
@@ -10,6 +10,8 @@ var _fs = _interopRequireDefault(require("fs"));
 
 var _path = _interopRequireDefault(require("path"));
 
+var _url = _interopRequireDefault(require("url"));
+
 var _react = _interopRequireWildcard(require("react"));
 
 var _propTypes = _interopRequireDefault(require("prop-types"));
@@ -37,7 +39,9 @@ function test(filePathOrUrl) {
     return false;
   }
 
-  if (!_path.default.isAbsolute(filePathOrUrl)) {
+  const isLocalPath = _path.default.isAbsolute(filePathOrUrl) || filePathOrUrl.startsWith("file:");
+
+  if (!isLocalPath) {
     return false;
   }
 
@@ -49,44 +53,51 @@ function test(filePathOrUrl) {
   }
 }
 
-const readExcalidraw = async filePath => {
+const readExcalidraw = async fileUrl => {
+  const filePath = _url.default.fileURLToPath(fileUrl);
+
   const content = await _fs.default.promises.readFile(filePath, "utf-8");
   return JSON.parse(content);
 };
 
 let exportToBlob = null;
 
-const updateNoteExcalidrawWithImage = filePath => {
+const updateNoteExcalidrawWithImage = ({
+  filePath,
+  fileUrl
+}) => {
   /**
    * @type {CodeMirror.Editor}
    */
   const cm = inkdrop.getActiveEditor().cm;
   const text = cm.getValue();
   const updatedText = text // Update timstamp ![Excalidraw](/path/to/file.excalidraw.png?updated=timestamp)
-  .replace(/(!\[Excalidraw]\((.*\.excalidraw)\.png\?updated=.*?\))/g, (all, link, matchFilePath) => {
-    if (matchFilePath !== filePath) {
+  .replace(/(!\[Excalidraw]\((.*\.excalidraw)\.png\?updated=.*?\))/g, (all, link, matchFileUrl) => {
+    if (matchFileUrl !== fileUrl) {
       return all; // no change
     }
 
-    const imageFilePath = matchFilePath + ".png";
+    const imageFilePath = filePath + ".png";
 
     if (_fs.default.existsSync(imageFilePath)) {
+      const imageFileUrl = fileUrl + ".png";
       const timeStamp = "?updated=" + (0, _dayjs.default)().format("YYYY-MM-DD--HH-mm-ss");
-      return `![Excalidraw](${imageFilePath + timeStamp})`;
+      return `![Excalidraw](${imageFileUrl + timeStamp})`;
     } else {
       return all;
     }
   }) // [!Excalidraw](/path/to/file.excalidraw) → ![Excalidraw](/path/to/file.excalidraw.png?updated=timestamp)
-  .replace(/(\[!Excalidraw]\((.*\.excalidraw)\))/g, (all, link, matchFilePath) => {
-    if (matchFilePath !== filePath) {
+  .replace(/(\[!Excalidraw]\((.*\.excalidraw)\))/g, (all, link, matchFileUrl) => {
+    if (matchFileUrl !== fileUrl) {
       return all; // no change
     }
 
-    const imageFilePath = matchFilePath + ".png";
+    const imageFilePath = filePath + ".png";
 
     if (_fs.default.existsSync(imageFilePath)) {
       const timeStamp = "?updated=" + (0, _dayjs.default)().format("YYYY-MM-DD--HH-mm-ss");
-      return `![Excalidraw](${imageFilePath + timeStamp})`;
+      const imageFileUrl = fileUrl + ".png";
+      return `![Excalidraw](${imageFileUrl + timeStamp})`;
     } else {
       return all;
     }
@@ -97,13 +108,15 @@ const updateNoteExcalidrawWithImage = filePath => {
   }
 };
 
-const writeExcalidraw = async (filePath, {
+const writeExcalidraw = async (fileUrl, {
   elements,
   appState
 }) => {
   if (elements.length === 0) {
     return; // does not save when no element
   }
+
+  const filePath = _url.default.fileURLToPath(fileUrl);
 
   if (!_fs.default.existsSync(filePath)) {
     return;
@@ -136,7 +149,10 @@ const writeExcalidraw = async (filePath, {
   const enabledInlineImageWidgets = inkdrop.config.get("excalidraw.inlineImageWidgets");
 
   if (enabledInlineImageWidgets) {
-    updateNoteExcalidrawWithImage(filePath);
+    updateNoteExcalidrawWithImage({
+      filePath,
+      fileUrl
+    });
   }
 };
 
@@ -156,11 +172,11 @@ function ExcalidrawWrapper(props) {
       return;
     }
 
-    writeExcalidraw(props.filePath, {
+    writeExcalidraw(props.fileUrl, {
       elements,
       appState
     }).catch(error => {
-      console.error("save error on " + props.filePath, error);
+      console.error("save error on " + props.fileUrl, error);
     });
   }, [excalidrawRef, updateAtLeastOne]), 500);
   const onPointerUpdate = (0, _react.useCallback)(() => {
@@ -174,12 +190,12 @@ function ExcalidrawWrapper(props) {
       }
     };
 
-    if (!props.filePath.endsWith(".excalidraw")) {
+    if (!props.fileUrl.endsWith(".excalidraw")) {
       return setInitialData(DEFAULT_STATE);
     }
 
-    readExcalidraw(props.filePath).then(state => setInitialData(state)).catch(error => {
-      console.error("parse error on " + props.filePath, error);
+    readExcalidraw(props.fileUrl).then(state => setInitialData(state)).catch(error => {
+      console.error("parse error on " + props.fileUrl, error);
       setInitialData(DEFAULT_STATE);
     });
     return () => {
@@ -220,7 +236,7 @@ function ExcalidrawWrapper(props) {
 }
 
 ExcalidrawWrapper.prototype.propTypes = {
-  filePath: _propTypes.default.string,
+  fileUrl: _propTypes.default.string,
   preview: _propTypes.default.object
 };
 const connector = (0, _reactRedux.connect)(({

--- a/lib/remark-anchor.js
+++ b/lib/remark-anchor.js
@@ -31,7 +31,7 @@ function createRemarkAnchor(OrigA) {
           if (provider.test(this.props.href)) {
             const Component = provider.default;
             return /*#__PURE__*/React.createElement(Component, {
-              filePath: this.props.href
+              fileUrl: this.props.href
             });
           }
         }

--- a/lib/remark-img.js
+++ b/lib/remark-img.js
@@ -29,10 +29,10 @@ function createRemarkImg(OrigA) {
       if (typeof alt === "string" && alt === "Excalidraw") {
         for (const provider of _providers.default) {
           if (provider.test(this.props.src)) {
-            const filePath = this.props.src.replace(/\.png(\?updated=.*)?$/, "");
+            const fileUrl = this.props.src.replace(/\.png(\?updated=.*)?$/, "");
             const Component = provider.default;
             return /*#__PURE__*/React.createElement(Component, {
-              filePath: filePath
+              fileUrl: fileUrl
             });
           }
         }

--- a/src/excalidraw.js
+++ b/src/excalidraw.js
@@ -4,6 +4,7 @@ import { markdownRenderer } from "inkdrop";
 import { CompositeDisposable } from "event-kit";
 
 import fs from "fs";
+import url from "url";
 import path from "path";
 import dayjs from "dayjs";
 import createRemarkImg from "./remark-img";
@@ -13,6 +14,11 @@ const insertText = (text) => {
     cm.replaceSelection(text + "\n");
 };
 
+/**
+ * Create new .excalidraw file and return file:/// url
+ * @param dirPath
+ * @returns {URL}
+ */
 const createExcalidraw = (dirPath) => {
     const DEFAULT_STATE = {
         type: "excalidraw",
@@ -28,7 +34,7 @@ const createExcalidraw = (dirPath) => {
     }
     const filePath = path.join(dirPath, dayjs().format("YYYY-MM-DD--HH-mm-ss") + ".excalidraw");
     fs.writeFileSync(filePath, JSON.stringify(DEFAULT_STATE), "utf-8");
-    return filePath;
+    return url.pathToFileURL(filePath);
 };
 const subscriptions = new CompositeDisposable();
 module.exports = {

--- a/src/excalidraw.js
+++ b/src/excalidraw.js
@@ -42,7 +42,7 @@ module.exports = {
     config: {
         saveDir: {
             title: "A saving directory for .excalidraw files",
-            description: "Put the path to directory for savind .excalidraw files",
+            description: "Put the path to directory for savind .excalidraw files. e.g. /path/to/excalidraw-files/",
             type: "string",
             default: ""
         },
@@ -65,7 +65,7 @@ module.exports = {
                         return alert("Please set saveDir of excalidraw plugin");
                     }
                     const outputFilePath = createExcalidraw(saveDir);
-                    insertText(`[!Excalidraw](${outputFilePath})`);
+                    insertText(`[!Excalidraw](${outputFilePath.toString()})`);
                 }
             })
         );

--- a/src/providers/excalidraw.js
+++ b/src/providers/excalidraw.js
@@ -15,8 +15,7 @@ export function test(filePathOrUrl) {
     if (!filePathOrUrl) {
         return false;
     }
-    const isLocalPath = path.isAbsolute(filePathOrUrl) || filePathOrUrl.startsWith("file:");
-    if (!isLocalPath) {
+    if (!filePathOrUrl.startsWith("file:")) {
         return false;
     }
     try {

--- a/src/remark-anchor.js
+++ b/src/remark-anchor.js
@@ -15,7 +15,7 @@ export default function createRemarkAnchor(OrigA) {
                 for (const provider of providers) {
                     if (provider.test(this.props.href)) {
                         const Component = provider.default;
-                        return <Component filePath={this.props.href} />;
+                        return <Component fileUrl={this.props.href} />;
                     }
                 }
             }

--- a/src/remark-img.js
+++ b/src/remark-img.js
@@ -15,9 +15,9 @@ export default function createRemarkImg(OrigA) {
             if (typeof alt === "string" && alt === "Excalidraw") {
                 for (const provider of providers) {
                     if (provider.test(this.props.src)) {
-                        const filePath = this.props.src.replace(/\.png(\?updated=.*)?$/, "");
+                        const fileUrl = this.props.src.replace(/\.png(\?updated=.*)?$/, "");
                         const Component = provider.default;
-                        return <Component filePath={filePath} />;
+                        return <Component fileUrl={fileUrl} />;
                     }
                 }
             }


### PR DESCRIPTION
BREAKING CHANGE: use `file:///path/to/file` instead of `/path/to/file`.

You need to rewrite file paths.

```diff
- ![Excalidraw](/Users/path/to/Memo/excalidraw/2021-05-07--22-26-17.excalidraw.png?updated=2021-05-08--10-30-10)
+ ![Excalidraw](file:///path/to/Memo/excalidraw/2021-05-07--22-26-17.excalidraw.png?updated=2021-05-08--10-30-10)
```


- remark-react escape Window's file path (`\`), and we need to avoid this escaping
- use `file:///path/to/file` instead of absolute file path

fix #5